### PR TITLE
feat: implement 'system prune' and build enhancements

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -31,6 +31,11 @@ If [path] is not provided, defaults to the current directory.`,
 			return fmt.Errorf("failed to validate skill: %w", err)
 		}
 
+		if buildTag == "" {
+			buildTag = fmt.Sprintf("%s:latest", s.Name)
+			fmt.Printf("No tag provided. Defaulting to: %s\n", buildTag)
+		}
+
 		ctx := cmd.Context()
 		st, err := store.New("")
 		if err != nil {
@@ -42,9 +47,7 @@ If [path] is not provided, defaults to the current directory.`,
 		}
 
 		fmt.Printf("Successfully built artifact for skill '%s'\n", s.Name)
-		if buildTag != "" {
-			fmt.Printf("Tagged as: %s\n", buildTag)
-		}
+		fmt.Printf("Tagged as: %s\n", buildTag)
 
 		return nil
 	},

--- a/cmd/system.go
+++ b/cmd/system.go
@@ -1,0 +1,15 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var systemCmd = &cobra.Command{
+	Use:   "system",
+	Short: "Manage system-wide resources",
+	Long:  `Manage system-wide resources such as storage and configuration.`,
+}
+
+func init() {
+	rootCmd.AddCommand(systemCmd)
+}

--- a/cmd/system_prune.go
+++ b/cmd/system_prune.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/andrewhowdencom/skr/pkg/store"
+	"github.com/spf13/cobra"
+)
+
+var systemPruneCmd = &cobra.Command{
+	Use:   "prune",
+	Short: "Remove unused data",
+	Long:  `Remove unused data (blob garbage collection). This command deletes any content in the local store that is not referenced by any tag.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		st, err := store.New("")
+		if err != nil {
+			return fmt.Errorf("failed to initialize store: %w", err)
+		}
+
+		ctx := cmd.Context()
+		count, size, err := st.Prune(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to prune system: %w", err)
+		}
+
+		fmt.Printf("Deleted %d artifacts\n", count)
+		fmt.Printf("Reclaimed %.2f MB\n", float64(size)/1024/1024)
+
+		return nil
+	},
+}
+
+func init() {
+	systemCmd.AddCommand(systemPruneCmd)
+}

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -123,7 +123,7 @@ func (s *Store) Build(ctx context.Context, srcDir string, tag string) error {
 		Size:      layerSize,
 	}
 
-	err = s.oci.Push(ctx, layerDesc, bytes.NewReader(layerBytes))
+	err = s.pushBlob(ctx, layerDesc, bytes.NewReader(layerBytes))
 	if err != nil {
 		return fmt.Errorf("failed to push layer: %w", err)
 	}
@@ -139,7 +139,7 @@ func (s *Store) Build(ctx context.Context, srcDir string, tag string) error {
 		Digest:    configDigest,
 		Size:      int64(len(configBytes)),
 	}
-	err = s.oci.Push(ctx, configDesc, bytes.NewReader(configBytes))
+	err = s.pushBlob(ctx, configDesc, bytes.NewReader(configBytes))
 	if err != nil {
 		return fmt.Errorf("failed to push config: %w", err)
 	}
@@ -163,7 +163,7 @@ func (s *Store) Build(ctx context.Context, srcDir string, tag string) error {
 		Size:      int64(len(manifestBytes)),
 	}
 
-	err = s.oci.Push(ctx, manifestDesc, bytes.NewReader(manifestBytes))
+	err = s.pushBlob(ctx, manifestDesc, bytes.NewReader(manifestBytes))
 	if err != nil {
 		return fmt.Errorf("failed to push manifest: %w", err)
 	}
@@ -202,5 +202,97 @@ func (s *Store) Resolve(ctx context.Context, ref string) (ocispec.Descriptor, er
 	return s.oci.Resolve(ctx, ref)
 }
 
+// Prune removes all unreferenced blobs from the store
+func (s *Store) Prune(ctx context.Context) (int, int64, error) {
+	// 1. Identify all reachable blobs
+	reachable := make(map[string]bool)
+
+	err := s.oci.Tags(ctx, "", func(tags []string) error {
+		for _, tag := range tags {
+			// Resolve tag to manifest descriptor
+			desc, err := s.oci.Resolve(ctx, tag)
+			if err != nil {
+				return err
+			}
+			reachable[desc.Digest.String()] = true
+
+			// Fetch and parse manifest to find children (config + layers)
+			rc, err := s.oci.Fetch(ctx, desc)
+			if err != nil {
+				return err
+			}
+			manifestBytes, err := io.ReadAll(rc)
+			rc.Close()
+			if err != nil {
+				return err
+			}
+
+			var manifest ocispec.Manifest
+			if err := json.Unmarshal(manifestBytes, &manifest); err != nil {
+				return err
+			}
+
+			// Mark config as reachable
+			reachable[manifest.Config.Digest.String()] = true
+
+			// Mark layers as reachable
+			for _, layer := range manifest.Layers {
+				reachable[layer.Digest.String()] = true
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to traverse tags: %w", err)
+	}
+
+	// 2. Iterate through all blobs in storage and delete unreachable ones
+	blobsDir := filepath.Join(s.path, "blobs", "sha256")
+	entries, err := os.ReadDir(blobsDir)
+	if os.IsNotExist(err) {
+		return 0, 0, nil // Nothing to prune
+	}
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to read blobs directory: %w", err)
+	}
+
+	deletedCount := 0
+	var deletedSize int64
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		digestStr := "sha256:" + entry.Name()
+		if !reachable[digestStr] {
+			info, err := entry.Info()
+			if err == nil {
+				deletedSize += info.Size()
+			}
+
+			path := filepath.Join(blobsDir, entry.Name())
+			if err := os.Remove(path); err != nil {
+				return deletedCount, deletedSize, fmt.Errorf("failed to remove blob %s: %w", path, err)
+			}
+			deletedCount++
+		}
+	}
+
+	return deletedCount, deletedSize, nil
+}
+
 // interface guard
 var _ content.Storage = &oci.Store{}
+
+// pushBlob pushes content if it doesn't already exist
+func (s *Store) pushBlob(ctx context.Context, desc ocispec.Descriptor, r io.Reader) error {
+	exists, err := s.oci.Exists(ctx, desc)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return nil
+	}
+	return s.oci.Push(ctx, desc, r)
+}


### PR DESCRIPTION
Adds garbage collection for the local store and improves build defaults.

Context:
- Over time, the local OCI store accumulates unreferenced blobs (orphan layers).
- Users often forget to tag builds, leading to harder discovery/management.
- Rebuilding the same artifact previously caused 'already exists' errors.

Solution:
- 'system prune': Deletes any blob in the store not reachable from a tag.
- 'build': Defaults to '<skill-name>:latest' if no tag is provided.
- 'store': Added existence check in 'pushBlob' to handle idempotency.

Anti-Regret:
- Implemented a rigorous mark-and-sweep GC rather than simple TTL expiration.