### PR TITLE
feat: refactor command structure to delimit contexts

### DIFF
--- a/cmd/images.go
+++ b/cmd/images.go
@@ -1,0 +1,74 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/andrewhowdencom/skr/pkg/store"
+	"github.com/spf13/cobra"
+)
+
+var imagesCmd = &cobra.Command{
+	Use:   "images",
+	Short: "List built/pulled artifacts in Local Registry",
+	Long: `List all skill artifacts stored in the local OCI registry.
+	
+Analogous to 'docker images'. Shows repository, tag, digest, and size.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+		st, err := store.New("")
+		if err != nil {
+			return fmt.Errorf("failed to initialize store: %w", err)
+		}
+
+		tags, err := st.List(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to list skills: %w", err)
+		}
+
+		// Header
+		fmt.Printf("%-30s %-15s %-15s %-10s\n", "REPOSITORY", "TAG", "IMAGE ID", "SIZE")
+
+		for _, tag := range tags {
+			// Resolve to get digest and size
+			desc, err := st.Resolve(ctx, tag)
+			if err != nil {
+				// warn and continue?
+				continue
+			}
+
+			// For REPOSITORY/TAG splitting, we assume standard "repo:tag" format.
+			repo := tag
+			version := "<none>"
+
+			if idx := lastIndex(tag, ":"); idx != -1 {
+				repo = tag[:idx]
+				version = tag[idx+1:]
+			}
+
+			// Short digest
+			digestVal := desc.Digest.String()
+			if len(digestVal) > 12 {
+				digestVal = digestVal[7:19] // sha256:1234... -> 1234...
+			}
+
+			// Size (human readable-ish)
+			size := fmt.Sprintf("%d B", desc.Size)
+			if desc.Size > 1024 {
+				size = fmt.Sprintf("%.2f KB", float64(desc.Size)/1024)
+			}
+
+			fmt.Printf("%-30s %-15s %-15s %-10s\n", repo, version, digestVal, size)
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(imagesCmd)
+}
+
+func lastIndex(s, sep string) int {
+	return strings.LastIndex(s, sep)
+}

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/andrewhowdencom/skr/pkg/discovery"
 	"github.com/andrewhowdencom/skr/pkg/skill"
 	"github.com/andrewhowdencom/skr/pkg/store"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -34,9 +35,9 @@ extracts it to the agent's skill directory.`,
 			return fmt.Errorf("failed to get current working directory: %w", err)
 		}
 
-		installDir, err := findInstallDir(cwd)
+		installDir, err := discovery.FindAgentSkillsDir(cwd)
 		if err != nil {
-			return err
+			return fmt.Errorf("agent context not found: %w. Please ensure you are inside a project with .agent/skills", err)
 		}
 
 		fmt.Printf("Installing to %s\n", installDir)
@@ -134,25 +135,6 @@ extracts it to the agent's skill directory.`,
 
 		return nil
 	},
-}
-
-func findInstallDir(startDir string) (string, error) {
-	dir := startDir
-	for {
-		target := filepath.Join(dir, ".agent", "skills")
-		info, err := os.Stat(target)
-		if err == nil && info.IsDir() {
-			return target, nil
-		}
-
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			break
-		}
-		dir = parent
-	}
-
-	return "", fmt.Errorf("could not find .agent/skills directory in any parent of %s. Please create it first.", startDir)
 }
 
 func unpackLayer(r io.Reader, dest string) error {

--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -1,0 +1,70 @@
+package discovery
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/andrewhowdencom/skr/pkg/skill"
+)
+
+// FindAgentSkillsDir traverses upwards from startDir to find .agent/skills
+func FindAgentSkillsDir(startDir string) (string, error) {
+	dir := startDir
+	for i := 0; i < 100; i++ { // Limit to 100 levels to prevent infinite loops/too deep
+		target := filepath.Join(dir, ".agent", "skills")
+		info, err := os.Stat(target)
+		if err == nil && info.IsDir() {
+			return target, nil
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+
+	return "", fmt.Errorf("could not find .agent/skills directory in any parent of %s", startDir)
+}
+
+// InstalledSkill represents a skill found in the agent's environment
+type InstalledSkill struct {
+	Name     string
+	Path     string
+	Version  string // From SKILL.md if available, else "unknown" (or we might parse it)
+	IsGlobal bool
+}
+
+// ListInstalledSkills discovers all skills in the .agent/skills directory accessible from startDir
+func ListInstalledSkills(startDir string) ([]InstalledSkill, error) {
+	var skills []InstalledSkill
+
+	// 1. Local Agent Skills
+	skillsDir, err := FindAgentSkillsDir(startDir)
+	if err == nil { // It's okay if not found, just return empty (or global only)
+		entries, err := os.ReadDir(skillsDir)
+		if err == nil {
+			for _, entry := range entries {
+				if entry.IsDir() {
+					skillPath := filepath.Join(skillsDir, entry.Name())
+					s, err := skill.Load(skillPath)
+					if err == nil {
+						skills = append(skills, InstalledSkill{
+							Name:     s.Name,
+							Path:     skillPath,
+							Version:  "local", // TODO: Parse version from SKILL.md content if added to spec
+							IsGlobal: false,
+						})
+					}
+				}
+			}
+		}
+	}
+
+	// 2. Global Skills (Placeholder for now)
+	// globalDir := ...
+	// merge...
+
+	return skills, nil
+}


### PR DESCRIPTION
Refactors the CLI to clearer distinctions between Agent, Local Registry, and Remote Registry contexts.

Context:
Users found the previous command structure confusing (e.g., 'list' listing built artifacts instead of installed skills).

Solution:
- Renamed 'cmd/list.go' to 'cmd/images.go' ('skr images') to match Docker conventions for listing local registry artifacts.
- Implemented new 'cmd/list.go' ('skr list') to list installed skills in the current Agent Context (hierarchical '.agent/skills' discovery).
- Extracted discovery logic to 'pkg/discovery'.

Anti-Regret:
- Aligns with standard package manager (npm list) vs container (docker images) mental models.