### PR TITLE
Add lockfile to guarantee reproducible agent skills resolution

### DIFF
--- a/.skr.lock
+++ b/.skr.lock
@@ -1,0 +1,4 @@
+skills:
+    ghcr.io/andrewhowdencom/skills.documentation:eca82c3: sha256:c491ea7eba0aa5b043a28b07c580e367638f87159a29e6b463648e0e3a0a72b0
+    ghcr.io/andrewhowdencom/skills.git:fb45f15: sha256:b3c1b9fadfb3bff43e9cdedb9734ca7d25b84e4ac0c30df3dc1e3ddfad0dde5d
+    ghcr.io/andrewhowdencom/skills.go:3fe18f2: sha256:5a8f586108ceeff51a8f86e1fb0bcef716f4935dc515ac25d2d4433c8ac79f01

--- a/.skr.yaml
+++ b/.skr.yaml
@@ -1,5 +1,5 @@
 agents: []
 skills:
-    - ghcr.io/andrewhowdencom/skills.git:latest
+    - ghcr.io/andrewhowdencom/skills.git:fb45f15
     - ghcr.io/andrewhowdencom/skills.go:3fe18f2
-    - ghcr.io/andrewhowdencom/skills.documentation:latest
+    - ghcr.io/andrewhowdencom/skills.documentation:eca82c3

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Since `skr` is self-hosting, the best examples are the files in this repository:
 *   **Skill Structure**: See `skills/builder/SKILL.md`
 *   **Workflow**: See `.github/workflows/publish-skills.yaml` for a production-ready GitHub Actions workflow to publish skills.
 *   **Configuration**: See `.skr.yaml` for an extensively documented configuration example.
+*   **Reproducibility**: See `.skr.lock` as the generated lockfile storing guaranteed immutable tag hashes.
 
 ## Installation
  

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -109,12 +109,27 @@ If --global is set, installs to the global configuration.`,
 		}
 
 		slog.Info("installing skill", "skill", ref, "path", installRoot)
-		name, err := action.InstallSkill(ctx, st, ref, installRoot)
+		name, digest, err := action.InstallSkill(ctx, st, ref, installRoot)
 		if err != nil {
 			return err
 		}
 
-		slog.Info("successfully installed skill", "name", name, "ref", ref)
+		lockFilePath := filepath.Join(filepath.Dir(configFilePath), config.LockFileName)
+		if !isGlobal {
+			lockFilePath = filepath.Join(filepath.Dir(configFilePath), config.AltLockFileName)
+		}
+		
+		lockFile, err := config.LoadLock(lockFilePath)
+		if err != nil {
+			return fmt.Errorf("failed to load lock file: %w", err)
+		}
+		
+		lockFile.Skills[ref] = digest
+		if err := lockFile.SaveTo(lockFilePath); err != nil {
+			return fmt.Errorf("failed to save lock file: %w", err)
+		}
+
+		slog.Info("successfully installed skill", "name", name, "ref", ref, "digest", digest)
 		return nil
 	},
 }

--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -26,7 +26,7 @@ content or preparing for offline installation.`,
 		}
 
 		fmt.Printf("Pulling %s...\n", ref)
-		if err := registry.Pull(ctx, st, ref); err != nil {
+		if _, err := registry.Pull(ctx, st, ref); err != nil {
 			return err
 		}
 

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/andrewhowdencom/skr/pkg/action"
 	"github.com/andrewhowdencom/skr/pkg/config"
@@ -65,39 +66,44 @@ var syncCmd = &cobra.Command{
 			return fmt.Errorf("failed to create install root %s: %w", installRoot, err)
 		}
 
-		// 4. Install missing skills
-		// Naive implementation: iterate config.Skills, checked if installed.
-		// NOTE: config.Skills might be "git:v1" or just "git".
-		// We need to resolve name.
+		// 4. Load Lock file
+		var lockFile *config.LockFile
+		lockFilePath, err := config.FindLockFile(projectRoot)
+		if err == nil {
+			lockFile, _ = config.LoadLock(lockFilePath)
+		} else {
+			lockFile = config.NewLockFile()
+			lockFilePath = filepath.Join(projectRoot, config.AltLockFileName)
+		}
+
+		// 5. Install missing skills
 		for _, ref := range cfg.Skills {
-			// Check if installed
-			// We need to parse name from ref?
-			// If ref is "git:v1", name is "git".
-			// If ref is "ghcr.io/mypkg/git:latest", name is "git"?
-			// Ideally config should map name -> ref, OR we parse ref.
-			// Simple parsing: last component before tag.
-			// For now, let's assume ref is compatible with what we expect.
-			// Wait, how do we know if it's already installed?
-			// By checking directory existence?
+			installRef := ref
+			
+			// If we have a locked digest and it's not already embedded in the ref
+			if lockedDigest, ok := lockFile.Skills[ref]; ok && !strings.Contains(ref, "@") && lockedDigest != "" {
+				// Strip tag if it exists when adding digest, because oras expects either tag OR digest.
+				// Ref format: domain/repo:tag
+				// If we append @digest to domain/repo:tag, containerd/docker accepts it (usually resolves to digest).
+				// We can simply pass the digest replacing the tag if we wanted to, or append it. 
+				// The image spec allows namespace/name:tag@digest.
+				installRef = ref + "@" + lockedDigest
+			}
 
-			// FIXME: name resolution is tricky without pulling.
-			// Let's rely on 'install' logic which unpacks to temp and gets name.
-			// For sync, efficiency matters.
-			// IF we mandate ref format <name>:<tag> or just <name>, we can guess.
-			// But for now, let's just attempt install if NOT skipping?
-
-			// Actually, let's call the install logic directly.
-			// Reusing logic from installCmd would be good.
-			// Moving install logic to a pkg/action or similar?
-			// For now, inline or copy/paste logic from install.go.
-
-			slog.Info("syncing skill", "ref", ref)
+			slog.Info("syncing skill", "ref", ref, "installRef", installRef)
 
 			// Install using the action package
-			_, err := action.InstallSkill(ctx, st, ref, installRoot)
+			_, digest, err := action.InstallSkill(ctx, st, installRef, installRoot)
 			if err != nil {
 				return fmt.Errorf("failed to install %s: %w", ref, err)
 			}
+			
+			lockFile.Skills[ref] = digest
+		}
+
+		// 6. Save Lock file
+		if err := lockFile.SaveTo(lockFilePath); err != nil {
+			return fmt.Errorf("failed to save lock file: %w", err)
 		}
 
 		return nil

--- a/docs/explanation/concepts.md
+++ b/docs/explanation/concepts.md
@@ -22,3 +22,4 @@ This compatibility allows `skr` to work with existing infrastructure like GitHub
 
 -   **System Store**: A global cache of all downloaded/built artifacts on your machine.
 -   **Project Scope**: When you run `skr install`, skills are "installed" into your project (referenced in `.skr.yaml` and synced to `.agent/skills`).
+-   **Lockfiles**: The `.skr.lock` file stores precise digests corresponding to the tags in `.skr.yaml`, guaranteeing reproducible skill resolution on subsequent `skr sync` operations across team environments.

--- a/docs/how-to/lock-skills.md
+++ b/docs/how-to/lock-skills.md
@@ -1,0 +1,40 @@
+# How-to: Managing Skill Dependencies with Lockfiles
+
+When developing AI agent skills recursively or maintaining dependent systems, the unpredictability of remote versions like `latest` or floating tag versions can lead to difficult tracking of regression errors.
+
+`skr` guarantees reproducibility by keeping a `.skr.lock` file alongside your declarative `.skr.yaml`. 
+
+This guide demonstrates how to properly manage versioning with `skr`.
+
+## Inspecting the Lockfile
+
+When you use the command `skr install <repository-url>:<tag>`, `skr` automatically creates a corresponding mapped digest in the `.skr.lock` file (usually an SHA-256 identifier containing the explicit manifest of that repository state).
+
+An example `.skr.lock` might look like this:
+```yaml
+skills:
+  ghcr.io/andrewhowdencom/skills.git:latest: sha256:4a001a1dbba4e55e0ef3...
+  ghcr.io/andrewhowdencom/skills.go:1.0: sha256:d8c6b75ffcb3a233ecbc...
+```
+
+Whenever the above skills are fetched using `skr sync`, the process strictly routes through `sha256:...` internally to avoid "floating tag" drift.
+
+## Updating a Locked Skill
+
+If you have downloaded a skill utilizing a floating tag equivalent like `:latest` or `:1.0` (which generally maps to `1.0.X` under semver conventions), the locked digest won't update itself automatically when a remote author updates the tag. 
+
+To upgrade to the newest manifestation of a floating tag:
+1. Open your terminal to the project root.
+2. Un-lock the dependency by manually removing it from the `.skr.lock` file under the text editor.
+3. Rerun `skr sync`. 
+
+The process will fetch the freshest image referenced by your `.skr.yaml` and recalculate a new locking digest inside `.skr.lock`.
+
+## Checking in the Lockfile
+
+It is highly recommended that you check **both** the `.skr.yaml` configuration and the `.skr.lock` cache tracking logs into your source version control system like Git.
+```bash
+git add .skr.yaml .skr.lock
+git commit -m "chore: hydrate skill locks"
+```
+This forces identical execution patterns for every remote or teammate environment.

--- a/docs/tutorials/managing-project.md
+++ b/docs/tutorials/managing-project.md
@@ -58,13 +58,13 @@ Run:
 skr sync
 ```
 
-This ensures that `.agent/skills` contains exactly what is listed in `.skr.yaml`.
+This ensures that `.agent/skills` contains exactly what is listed in `.skr.yaml`. If you have a `.skr.lock` file, it will reliably resolve tags to the exact image digests that were originally installed, creating deterministic developer environments.
 
 ## 4. Version Control Guidelines
 
 When using `skr` in a team or CI/CD environment, following these `.gitignore` best practices is recommended:
 
--   **Commit**: `.skr.yaml` (This is your source of truth).
+-   **Commit**: `.skr.yaml` and `.skr.lock` (These are your source of truth and determine reproducible versions).
 -   **Ignore**: `.agent/skills/` (These are generated artifacts, similar to `node_modules`).
 
 Add to your `.gitignore`:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,6 +54,7 @@ nav:
     - Manage Registry: how-to/manage-registry.md
     - Manage System: how-to/manage-system.md
     - GitHub Packages: how-to/use-github-packages.md
+    - Lock Skills: how-to/lock-skills.md
   - Explanation:
     - Core Concepts: explanation/concepts.md
   - Reference:

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -18,39 +18,42 @@ import (
 )
 
 // InstallSkill installs a skill and its dependencies from the store to the installDir.
-func InstallSkill(ctx context.Context, st *store.Store, ref, installDir string) (string, error) {
-	// 1. Resolve all dependencies
+// Returns the root name, manifest digest, and error.
+func InstallSkill(ctx context.Context, st *store.Store, ref, installDir string) (string, string, error) {
 	// 1. Resolve all dependencies
 	resolver := resolution.New(st)
 	resolver.SetPuller(func(ctx context.Context, ref string) error {
 		fmt.Printf("Pulling missing dependency %s...\n", ref)
-		return registry.Pull(ctx, st, ref)
+		_, err := registry.Pull(ctx, st, ref)
+		return err
 	})
 
 	refs, err := resolver.Resolve(ctx, ref)
 	if err != nil {
-		return "", fmt.Errorf("failed to resolve dependencies for %s: %w", ref, err)
+		return "", "", fmt.Errorf("failed to resolve dependencies for %s: %w", ref, err)
 	}
 
 	var rootName string
+	var rootDigest string
 
 	// 2. Install each skill (sequentially for now)
 	for i, r := range refs {
-		name, err := installOne(ctx, st, r, installDir)
+		name, d, err := installOne(ctx, st, r, installDir)
 		if err != nil {
-			return "", fmt.Errorf("failed to install %s: %w", r, err)
+			return "", "", fmt.Errorf("failed to install %s: %w", r, err)
 		}
 
 		// The first one in the resolved list is the root skill (BFS start)
 		if i == 0 {
 			rootName = name
+			rootDigest = d
 		}
 	}
 
-	return rootName, nil
+	return rootName, rootDigest, nil
 }
 
-func installOne(ctx context.Context, st *store.Store, ref, installDir string) (string, error) {
+func installOne(ctx context.Context, st *store.Store, ref, installDir string) (string, string, error) {
 	// 1. Resolve Reference locally
 	desc, err := st.Resolve(ctx, ref)
 	shouldPull := false
@@ -72,43 +75,41 @@ func installOne(ctx context.Context, st *store.Store, ref, installDir string) (s
 
 	if shouldPull {
 		fmt.Printf("Pulling %s...\n", ref)
-		if err := registry.Pull(ctx, st, ref); err != nil {
+		var pullDesc ocispec.Descriptor
+		var pullErr error
+		if pullDesc, pullErr = registry.Pull(ctx, st, ref); pullErr != nil {
 			// If pull fails:
 			// 1. If we have local copy, maybe warn and use it?
 			// 2. If no local copy, fail.
 			if desc.Digest != "" { // We had a local copy
-				fmt.Printf("Warning: Failed to pull latest (using local copy): %v\n", err)
+				fmt.Printf("Warning: Failed to pull latest (using local copy): %v\n", pullErr)
 			} else {
-				return "", fmt.Errorf("failed to pull %s: %w", ref, err)
+				return "", "", fmt.Errorf("failed to pull %s: %w", ref, pullErr)
 			}
 		} else {
-			// Re-resolve after pull to get new descriptor
-			desc, err = st.Resolve(ctx, ref)
-			if err != nil {
-				return "", fmt.Errorf("failed to resolve %s after pull: %w", ref, err)
-			}
+			desc = pullDesc
 		}
 	}
 
 	// 2. Fetch Manifest
 	manifestReader, err := st.Fetch(ctx, desc)
 	if err != nil {
-		return "", fmt.Errorf("failed to fetch manifest: %w", err)
+		return "", "", fmt.Errorf("failed to fetch manifest: %w", err)
 	}
 	defer manifestReader.Close()
 
 	manifestBytes, err := io.ReadAll(manifestReader)
 	if err != nil {
-		return "", fmt.Errorf("failed to read manifest: %w", err)
+		return "", "", fmt.Errorf("failed to read manifest: %w", err)
 	}
 
 	var manifest ocispec.Manifest
 	if err := json.Unmarshal(manifestBytes, &manifest); err != nil {
-		return "", fmt.Errorf("failed to parse manifest: %w", err)
+		return "", "", fmt.Errorf("failed to parse manifest: %w", err)
 	}
 
 	if len(manifest.Layers) != 1 {
-		return "", fmt.Errorf("expected exactly 1 layer, got %d", len(manifest.Layers))
+		return "", "", fmt.Errorf("expected exactly 1 layer, got %d", len(manifest.Layers))
 	}
 
 	layerDesc := manifest.Layers[0]
@@ -116,26 +117,26 @@ func installOne(ctx context.Context, st *store.Store, ref, installDir string) (s
 	// 3. Fetch Layer
 	layerReader, err := st.Fetch(ctx, layerDesc)
 	if err != nil {
-		return "", fmt.Errorf("failed to fetch layer: %w", err)
+		return "", "", fmt.Errorf("failed to fetch layer: %w", err)
 	}
 	defer layerReader.Close()
 
 	// 4. Unpack Layer to Temp
 	tempDir, err := os.MkdirTemp("", "skr-install-*")
 	if err != nil {
-		return "", fmt.Errorf("failed to create temp dir: %w", err)
+		return "", "", fmt.Errorf("failed to create temp dir: %w", err)
 	}
 	defer os.RemoveAll(tempDir)
 
 	if err := unpackLayer(layerReader, tempDir); err != nil {
-		return "", fmt.Errorf("failed to unpack layer: %w", err)
+		return "", "", fmt.Errorf("failed to unpack layer: %w", err)
 	}
 
 	// 5. Read SKILL.md to get the name
 	s, err := skill.LoadUnverified(tempDir)
 	if err != nil {
 		// If we can't even load it (missing file, invalid yaml), we still fail as we need the name.
-		return "", fmt.Errorf("downloaded artifact is not a recognizable skill: %w", err)
+		return "", "", fmt.Errorf("downloaded artifact is not a recognizable skill: %w", err)
 	}
 
 	// Soft Validate: check if it's strictly valid, but don't fail, just warn.
@@ -145,22 +146,22 @@ func installOne(ctx context.Context, st *store.Store, ref, installDir string) (s
 
 	targetPath := filepath.Join(installDir, s.Name)
 	if err := os.MkdirAll(filepath.Dir(targetPath), 0755); err != nil {
-		return "", fmt.Errorf("failed to create parent dir: %w", err)
+		return "", "", fmt.Errorf("failed to create parent dir: %w", err)
 	}
 
 	// 6. Move tempDir to targetPath (replace if exists)
 	if err := os.RemoveAll(targetPath); err != nil {
-		return "", fmt.Errorf("failed to remove existing skill at %s: %w", targetPath, err)
+		return "", "", fmt.Errorf("failed to remove existing skill at %s: %w", targetPath, err)
 	}
 
 	if err := os.Rename(tempDir, targetPath); err != nil {
 		// Fallback: Copy content
 		if err := copyDir(tempDir, targetPath); err != nil {
-			return "", fmt.Errorf("failed to move skill to install dir: %w", err)
+			return "", "", fmt.Errorf("failed to move skill to install dir: %w", err)
 		}
 	}
 
-	return s.Name, nil
+	return s.Name, string(desc.Digest), nil
 }
 
 func unpackLayer(r io.Reader, dest string) error {

--- a/pkg/config/lock.go
+++ b/pkg/config/lock.go
@@ -1,0 +1,85 @@
+package config
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	LockFileName    = "config.lock"
+	AltLockFileName = ".skr.lock"
+)
+
+type LockFile struct {
+	Skills map[string]string `yaml:"skills"`
+}
+
+func NewLockFile() *LockFile {
+	return &LockFile{
+		Skills: make(map[string]string),
+	}
+}
+
+// LoadLock reads the lockfile from a specific path
+func LoadLock(path string) (*LockFile, error) {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		slog.Debug("lock file not found", "path", path)
+		return NewLockFile(), nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to read lock file %s: %w", path, err)
+	}
+
+	var l LockFile
+	if err := yaml.Unmarshal(data, &l); err != nil {
+		return nil, fmt.Errorf("failed to parse lock file %s: %w", path, err)
+	}
+
+	if l.Skills == nil {
+		l.Skills = make(map[string]string)
+	}
+
+	return &l, nil
+}
+
+// FindLockFile traverses upwards from startDir looking for .skr.lock or config.lock
+func FindLockFile(startDir string) (string, error) {
+	dir := startDir
+	for i := 0; i < 100; i++ {
+		legacyPath := filepath.Join(dir, AltLockFileName)
+		if _, err := os.Stat(legacyPath); err == nil {
+			return legacyPath, nil
+		}
+
+		xdgPath := filepath.Join(dir, LockFileName)
+		if _, err := os.Stat(xdgPath); err == nil {
+			return xdgPath, nil
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	return "", os.ErrNotExist
+}
+
+// Save persists the lockfile to the given path
+func (l *LockFile) SaveTo(path string) error {
+	data, err := yaml.Marshal(l)
+	if err != nil {
+		return fmt.Errorf("failed to marshal lock file: %w", err)
+	}
+
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		return fmt.Errorf("failed to write lock file to %s: %w", path, err)
+	}
+
+	return nil
+}

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -7,6 +7,7 @@ import (
 
 	skrauth "github.com/andrewhowdencom/skr/pkg/auth"
 	"github.com/andrewhowdencom/skr/pkg/store"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/registry/remote"
@@ -65,10 +66,10 @@ func Push(ctx context.Context, st *store.Store, ref string) error {
 }
 
 // Pull downloads a skill artifact from a remote registry to the local store.
-func Pull(ctx context.Context, st *store.Store, ref string) error {
+func Pull(ctx context.Context, st *store.Store, ref string) (ocispec.Descriptor, error) {
 	repo, err := remote.NewRepository(ref)
 	if err != nil {
-		return fmt.Errorf("invalid reference %s: %w", ref, err)
+		return ocispec.Descriptor{}, fmt.Errorf("invalid reference %s: %w", ref, err)
 	}
 
 	baseTransport := otelhttp.NewTransport(http.DefaultTransport)
@@ -91,10 +92,10 @@ func Pull(ctx context.Context, st *store.Store, ref string) error {
 		srcRef = "latest"
 	}
 
-	_, err = oras.Copy(ctx, repo, srcRef, st, ref, oras.DefaultCopyOptions)
+	desc, err := oras.Copy(ctx, repo, srcRef, st, ref, oras.DefaultCopyOptions)
 	if err != nil {
-		return fmt.Errorf("failed to pull %s: %w", ref, err)
+		return ocispec.Descriptor{}, fmt.Errorf("failed to pull %s: %w", ref, err)
 	}
 
-	return nil
+	return desc, nil
 }


### PR DESCRIPTION
Design:
  Implement a lockfile (.skr.lock) to map mutable tags to immutable
  OCI image descriptors. Update Config, CLI and Install logic to
  transparently generate and consume this file.

Tradeoffs:
  Negligible additional disk I/O when synchronizing.

Justification:
  Mutable skill tags (like :latest) cause divergent developer
  environments. Pinning via SHA-256 resolves this non-determinism.