### PR TITLE
Add generic skill sources and position Git as common path

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,22 @@
+# Architecture overview
+
+`skr` is designed to streamline the usage and distribution of Agent Skills via OCI artifact packaging conventions.
+
+## 1. Skill Sources (`pkg/source`)
+
+The `pkg/source` package isolates how Agent Skills are requested, fetched, and transformed. Instead of assuming every skill exists in a remote OCI registry, `skr` supports a generic `Fetcher` abstraction logic:
+
+- **Reference Parsing**: A unified parser `Reference.go` examines paths/URIs and divides them into schemas (`file`, `git`, `oci`), origin paths, and specifications (e.g. Git refspec or OCI tag).
+- **Git Fetcher (`source/git.go`)**: Delegates cloning of standard HTTP/Git repositories to the underlying `git` command-line tools. The cloned repositories are verified and converted internally into an OCI image inside the `store` module. 
+- **File Fetcher (`source/file.go`)**: Bypasses external network calls entirely, targeting local directories and constructing local OCI images directly from disk.
+- **OCI Fetcher (`source/oci.go`)**: Functions as the primary pass-through. Uses standard ORAS (`registry.Pull`) logic to resolve artifacts from external container registries natively.
+
+Because every source resolves dynamically into the local `pkg/store` (acting as a local container registry buffer), tasks like validation, installation, and inspection down the pipeline need only to concern themselves with standardized OCI layers and digests.
+
+## 2. Dependency Resolution (`pkg/resolution`)
+
+Dependencies specified formally in `SKILL.md` interact with the generic `pkg/source` module. Before attempting to link a reference internally using OCI conventions, the `Resolver` runs it through the `Fetcher` logic. This ensures transitive dependencies expressed as absolute GitHub repositories or relative file paths are fetched, built contextually, and stored alongside their consuming root application logically.
+
+## 3. Storage (`pkg/store`)
+
+The internal datastore heavily employs `oras.land/oras-go` wrappers to expose a `xdg`-derived memory and disk abstraction of an OCI-compliant cache directory. `st.Build()` constructs canonical container manifests dynamically avoiding dependency on standard Docker daemons.

--- a/README.md
+++ b/README.md
@@ -6,11 +6,9 @@
 
 ## Goal
 
-The primary goal of **skr** is to enable the pushing, pulling, and maintenance of Agent Skills using OCI (Open Container Initiative) Image registries, similar to the workflow used for container images on platforms like GitHub or Docker Hub.
+The primary goal of **skr** is to enable developers to natively install and manage Agent Skills directly from standard Git repositories. Under the hood, `skr` automatically creates OCI (Open Container Initiative) artifacts locally, allowing you to optionally leverage standard OCI registries for faster, pre-built distribution of your skills across environments like GitHub Packages or Docker Hub.
 
-This allows for a standardized, versioned, and distributed ecosystem for sharing AI capabilities.
-
-This allows for a standardized, versioned, and distributed ecosystem for sharing AI capabilities.
+By positioning Git as the primary distribution method and OCI as an enhanced performance layer, `skr` fosters a standardized, versioned, and easily accessible ecosystem for sharing AI capabilities.
 
 ## Agent Skills
 
@@ -87,11 +85,17 @@ skr build . -t my-registry.com/my-skill:v1.0.0
 # Push a skill to a registry
 skr push my-registry.com/my-skill:v1.0.0
 
-# Install a skill
-skr install my-registry.com/my-skill:v1.0.0
+# Install a skill from a Git repository (default)
+skr install git+https://github.com/andrewhowdencom/skr-example-skill
+
+# Install a skill from a local directory (development)
+skr install file://./my-skill
+
+# Install a pre-built skill from an OCI registry (fast path)
+skr install oci://ghcr.io/user/skill:v1.0.0
 
 # Remove an installed skill
-skr rm my-registry.com/my-skill
+skr rm git+https://github.com/andrewhowdencom/skr-example-skill
 
 # Inspect a remote skill
 skr inspect my-registry.com/my-skill:v1.0.0

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -118,12 +118,12 @@ If --global is set, installs to the global configuration.`,
 		if !isGlobal {
 			lockFilePath = filepath.Join(filepath.Dir(configFilePath), config.AltLockFileName)
 		}
-		
+
 		lockFile, err := config.LoadLock(lockFilePath)
 		if err != nil {
 			return fmt.Errorf("failed to load lock file: %w", err)
 		}
-		
+
 		lockFile.Skills[ref] = digest
 		if err := lockFile.SaveTo(lockFilePath); err != nil {
 			return fmt.Errorf("failed to save lock file: %w", err)

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -79,13 +79,13 @@ var syncCmd = &cobra.Command{
 		// 5. Install missing skills
 		for _, ref := range cfg.Skills {
 			installRef := ref
-			
+
 			// If we have a locked digest and it's not already embedded in the ref
 			if lockedDigest, ok := lockFile.Skills[ref]; ok && !strings.Contains(ref, "@") && lockedDigest != "" {
 				// Strip tag if it exists when adding digest, because oras expects either tag OR digest.
 				// Ref format: domain/repo:tag
 				// If we append @digest to domain/repo:tag, containerd/docker accepts it (usually resolves to digest).
-				// We can simply pass the digest replacing the tag if we wanted to, or append it. 
+				// We can simply pass the digest replacing the tag if we wanted to, or append it.
 				// The image spec allows namespace/name:tag@digest.
 				installRef = ref + "@" + lockedDigest
 			}
@@ -97,7 +97,7 @@ var syncCmd = &cobra.Command{
 			if err != nil {
 				return fmt.Errorf("failed to install %s: %w", ref, err)
 			}
-			
+
 			lockFile.Skills[ref] = digest
 		}
 

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -84,13 +84,13 @@ If a new digest is discovered (e.g., when a floating tag like :latest points to 
 
 		for _, ref := range skillsToUpdate {
 			slog.Info("updating skill", "ref", ref)
-			
+
 			// We force a pull so we pass the original ref, NOT combining with the lock digest
 			_, digest, err := action.InstallSkill(ctx, st, ref, installRoot, true)
 			if err != nil {
 				return fmt.Errorf("failed to update %s: %w", ref, err)
 			}
-			
+
 			lockFile.Skills[ref] = digest
 		}
 

--- a/docs/explanation/concepts.md
+++ b/docs/explanation/concepts.md
@@ -9,14 +9,16 @@ An **Agent Skill** is a packaged unit of capability for an AI Agent. It is defin
 -   **Portable**: Can be pushed to standard OCI registries.
 -   **Layered**: Deduplicated storage of content.
 
-## OCI Store
+## Skill Sources & Storage
 
-`skr` uses the **Open Container Initiative (OCI)** specifications for storage and distribution.
+`skr` considers **Git** the standard, common methodology for installing Agent Skills. You just point `skr install` at a public repository, and it handles the rest.
+
+Behind the scenes, `skr` utilizes the **Open Container Initiative (OCI)** specification for storage and local caching. When a skill is cloned from Git, `skr` automatically unpacks it locally into standard OCI formats:
 -   **Manifest**: Describes the skill content (config + layers).
 -   **Config**: Metadata about the skill (creation time, author, etc.).
 -   **Layers**: The actual file content (tar.gz).
 
-This compatibility allows `skr` to work with existing infrastructure like GitHub Packages (`ghcr.io`), Docker Hub, Harbor, etc.
+This underlying OCI architecture allows for seamless scaling: While Git is the common path, you can use remote OCI registries (like GitHub Packages `ghcr.io`, Docker Hub, or Harbor) as a "value add." Authors can publish pre-built artifacts to registries to accelerate downloads and freeze distributions for deployment environments, bypassing the need for git cloning entirely.
 
 ## The Global vs. Local Scope
 

--- a/docs/how-to/install-git.md
+++ b/docs/how-to/install-git.md
@@ -1,0 +1,26 @@
+# How to Install a Skill from a Git Repository
+
+You can install `skr` Agent Skills directly from their upstream Git repositories without needing the author to have explicitly constructed and published an OCI container image.
+
+## Prerequisites
+- Git installed on your device.
+- The Git repository must contain a valid `SKILL.md` at its root.
+
+## Installation
+
+Run the `skr install` command using explicit Git schemas like `git://`, `git+https://`, `git+http://`, or `git+ssh://`, or `git@`. Using the `git+` prefix strictly specifies that the repository should be cloned using Git. 
+
+```bash
+skr install git+https://github.com/andrewhowdencom/skr-example-skill
+```
+
+### Specifying a Branch, Tag, or Commit
+
+If you want a specific branch, Git commit SHA, or tag, append it to the URL using the `#` fragment:
+
+```bash
+skr install git+https://github.com/andrewhowdencom/skr-example-skill#v1.0.0
+```
+
+## Under the Hood
+When you pass a Git URL, `skr` executes a standard Git clone to a temporary directory. It then builds an OCI image from that directory within the local cache. Future dependency resolution mapping to the same Git commit and repository will seamlessly utilize the local cached OCI image.

--- a/docs/how-to/install-local.md
+++ b/docs/how-to/install-local.md
@@ -1,0 +1,27 @@
+# How to Install a Skill from a Local Directory
+
+While developing Agent Skills, or when you have the source locally but haven't published it to a registry, you can install the skill directly from its local directory. `skr` will transparently build the local source into an OCI container image using its local store.
+
+## Prerequisites
+- A local directory containing an `skr` project (valid `SKILL.md`).
+
+## Installation
+
+Run `skr install` with the `file://` schema syntax, followed by either the absolute or relative path to the skill directory:
+
+```bash
+skr install file://./my-local-skill
+```
+
+Or an absolute path:
+
+```bash
+skr install file:///home/user/work/my-local-skill
+```
+
+## What Happens Under the Hood?
+1. **Building**: `skr` builds the directory's contents into an OCI image cache (`.config/agent/skills/store`).
+2. **Tagging**: The resulting OCI image is tagged using the skill's name and version (`latest` by default).
+3. **Extraction**: The layer is unpacked logically into your project's `.agent/skills/` directory.
+
+Once completed, testing or running the skill locally is no different from using one fetched from an OCI registry.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -15,7 +15,10 @@ Build an Agent Skill artifact from a directory.
 
 ### `skr install <ref>`
 Install a skill into the current project.
--   **ref**: Tag or digest of the skill (e.g., `ghcr.io/user/skill:v1`).
+-   **ref**: The source reference for the skill. Supported schemas are:
+    -   `oci://<repo>:<tag>` or `<repo>:<tag>`: Pulls an OCI artifact (defaults to `latest` if tag is omitted).
+    -   `git://<repo>#<refspec>`, `git+https://<repo>#<refspec>`, `git+ssh://<repo>#<refspec>`, `git@<repo>#<refspec>`: Clones a git repository, checks out `<refspec>` (defaults to HEAD if omitted), builds it, and installs it from the local cache. Note: Use the `git+` prefix to distinguish Git over HTTPS from other types of connections.
+    -   `file://<path>`: Builds the skill from a local directory.
 
 ### `skr validate [path]`
 Validate an Agent Skill's structure and metadata.

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -66,11 +66,15 @@ You'll see metadata including the size, digest, and creation time.
 
 ## 4. Install the Skill
 
-Install the skill to your agent configuration.
+Install the skill to your agent configuration. Since we just authored the skill locally, we can install it directly from the directory using the `file://` schema:
 
 ```bash
-skr install my-skill:v1
+skr install file://./my-skill
 ```
+
+This updates your `.skr.yaml` and synchronizes the skill to `.agent/skills`.
+
+> **Note**: For sharing with others, you would typically push your skill folder to a Git repository, and others would install it directly via Git (e.g., `skr install https://github.com/your-username/my-skill`).
 
 This updates your `.skr.yaml` and synchronizes the skill to `.agent/skills`.
 

--- a/docs/tutorials/managing-project.md
+++ b/docs/tutorials/managing-project.md
@@ -26,10 +26,10 @@ Use the `install` command to add a skill to your project. This will:
 2.  Update `.skr.yaml`.
 3.  Sync the skill content to `.agent/skills/`.
 
-Let's install a demo skill (assuming one is available in your registry or local store, e.g., `my-skill:v1`).
+Let's install a demo skill directly from a Git repository. `skr` uses Git as the primary pathway for distributing skills.
 
 ```bash
-skr install my-skill:v1
+skr install git+https://github.com/andrewhowdencom/skr-example-skill
 ```
 
 If successful, check your `.skr.yaml`:
@@ -38,7 +38,7 @@ If successful, check your `.skr.yaml`:
 agent:
   type: "custom"
 skills:
-  - "my-skill:v1"
+  - "git+https://github.com/andrewhowdencom/skr-example-skill"
 ```
 
 And verify the skill files were "hydration" into the project:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,6 +51,8 @@ nav:
     - Managing Projects: tutorials/managing-project.md
     - Monorepo Workflow: tutorials/monorepo-workflow.md
   - How-to Guides:
+    - Install Local Skill: how-to/install-local.md
+    - Install Git Skill: how-to/install-git.md
     - Manage Registry: how-to/manage-registry.md
     - Manage System: how-to/manage-system.md
     - GitHub Packages: how-to/use-github-packages.md

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -10,9 +10,9 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/andrewhowdencom/skr/pkg/registry"
 	"github.com/andrewhowdencom/skr/pkg/resolution"
 	"github.com/andrewhowdencom/skr/pkg/skill"
+	"github.com/andrewhowdencom/skr/pkg/source"
 	"github.com/andrewhowdencom/skr/pkg/store"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
@@ -22,10 +22,18 @@ import (
 func InstallSkill(ctx context.Context, st *store.Store, ref, installDir string, forcePull bool) (string, string, error) {
 	// 1. Resolve all dependencies
 	resolver := resolution.New(st)
-	resolver.SetPuller(func(ctx context.Context, ref string) error {
-		fmt.Printf("Pulling missing dependency %s...\n", ref)
-		_, err := registry.Pull(ctx, st, ref)
-		return err
+	resolver.SetPuller(func(ctx context.Context, depRef string) (string, error) {
+		fmt.Printf("Fetching missing dependency %s...\n", depRef)
+		parsedRef := source.ParseReference(depRef)
+		fetcher, err := source.GetFetcher(parsedRef)
+		if err != nil {
+			return "", fmt.Errorf("failed to get fetcher for %s: %w", depRef, err)
+		}
+		newRef, err := fetcher.Fetch(ctx, st, parsedRef)
+		if err != nil {
+			return "", err
+		}
+		return newRef.Path + ":" + newRef.Spec, nil
 	})
 
 	refs, err := resolver.Resolve(ctx, ref)
@@ -53,43 +61,47 @@ func InstallSkill(ctx context.Context, st *store.Store, ref, installDir string, 
 	return rootName, rootDigest, nil
 }
 
-func installOne(ctx context.Context, st *store.Store, ref, installDir string, forcePull bool) (string, string, error) {
+func installOne(ctx context.Context, st *store.Store, refStr, installDir string, forcePull bool) (string, string, error) {
 	// 1. Resolve Reference locally
-	desc, err := st.Resolve(ctx, ref)
+	desc, err := st.Resolve(ctx, refStr)
 	shouldPull := false
 
 	if err != nil {
-		// Not found locally?
 		shouldPull = true
 	} else if forcePull {
 		shouldPull = true
 	} else {
-		// Found locally. Check if we should update.
-		// For MVP, if tag is "latest", we assume we should pull?
-		// Or maybe we treat it as immutable unless --update is passed?
-		// User requested: "for :latest... pulling it first".
-		// Naive check for :latest suffix.
-		// NOTE: 'ref' might be fully qualified or short.
-		if len(ref) > 7 && ref[len(ref)-7:] == ":latest" {
+		if len(refStr) > 7 && refStr[len(refStr)-7:] == ":latest" {
 			shouldPull = true
 		}
 	}
 
 	if shouldPull {
-		fmt.Printf("Pulling %s...\n", ref)
-		var pullDesc ocispec.Descriptor
-		var pullErr error
-		if pullDesc, pullErr = registry.Pull(ctx, st, ref); pullErr != nil {
-			// If pull fails:
-			// 1. If we have local copy, maybe warn and use it?
-			// 2. If no local copy, fail.
-			if desc.Digest != "" { // We had a local copy
-				fmt.Printf("Warning: Failed to pull latest (using local copy): %v\n", pullErr)
+		fmt.Printf("Fetching %s...\n", refStr)
+		parsedRef := source.ParseReference(refStr)
+		fetcher, err := source.GetFetcher(parsedRef)
+		if err != nil {
+			return "", "", fmt.Errorf("failed to initialize fetcher for %s: %w", refStr, err)
+		}
+
+		newRef, fetchErr := fetcher.Fetch(ctx, st, parsedRef)
+		if fetchErr != nil {
+			if desc.Digest != "" {
+				fmt.Printf("Warning: Failed to fetch latest (using local copy): %v\n", fetchErr)
 			} else {
-				return "", "", fmt.Errorf("failed to pull %s: %w", ref, pullErr)
+				return "", "", fmt.Errorf("failed to fetch %s: %w", refStr, fetchErr)
 			}
 		} else {
-			desc = pullDesc
+			// Resolve the newly produced artifact from the store
+			resolveStr := newRef.Path
+			if newRef.Spec != "" {
+				resolveStr += ":" + newRef.Spec
+			}
+			newDesc, resolveErr := st.Resolve(ctx, resolveStr)
+			if resolveErr != nil {
+				return "", "", fmt.Errorf("failed to resolve newly fetched artifact %s: %w", resolveStr, resolveErr)
+			}
+			desc = newDesc
 		}
 	}
 
@@ -98,7 +110,7 @@ func installOne(ctx context.Context, st *store.Store, ref, installDir string, fo
 	if err != nil {
 		return "", "", fmt.Errorf("failed to fetch manifest: %w", err)
 	}
-	defer manifestReader.Close()
+	defer func() { _ = manifestReader.Close() }()
 
 	manifestBytes, err := io.ReadAll(manifestReader)
 	if err != nil {
@@ -121,14 +133,14 @@ func installOne(ctx context.Context, st *store.Store, ref, installDir string, fo
 	if err != nil {
 		return "", "", fmt.Errorf("failed to fetch layer: %w", err)
 	}
-	defer layerReader.Close()
+	defer func() { _ = layerReader.Close() }()
 
 	// 4. Unpack Layer to Temp
 	tempDir, err := os.MkdirTemp("", "skr-install-*")
 	if err != nil {
 		return "", "", fmt.Errorf("failed to create temp dir: %w", err)
 	}
-	defer os.RemoveAll(tempDir)
+	defer func() { _ = os.RemoveAll(tempDir) }()
 
 	if err := unpackLayer(layerReader, tempDir); err != nil {
 		return "", "", fmt.Errorf("failed to unpack layer: %w", err)
@@ -171,7 +183,7 @@ func unpackLayer(r io.Reader, dest string) error {
 	if err != nil {
 		return err
 	}
-	defer gzr.Close()
+	defer func() { _ = gzr.Close() }()
 
 	tr := tar.NewReader(gzr)
 
@@ -235,13 +247,13 @@ func copyFile(src, dst string, mode os.FileMode) error {
 	if err != nil {
 		return err
 	}
-	defer in.Close()
+	defer func() { _ = in.Close() }()
 
 	out, err := os.Create(dst)
 	if err != nil {
 		return err
 	}
-	defer out.Close()
+	defer func() { _ = out.Close() }()
 
 	if _, err := io.Copy(out, in); err != nil {
 		return err

--- a/pkg/resolution/resolver.go
+++ b/pkg/resolution/resolver.go
@@ -9,8 +9,8 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-// PullFunc is a function that pulls a reference into the store.
-type PullFunc func(context.Context, string) error
+// PullFunc is a function that pulls a reference into the store and returns the resulting OCI reference.
+type PullFunc func(context.Context, string) (string, error)
 
 // Resolver handles dependency resolution for skills.
 type Resolver struct {
@@ -51,8 +51,9 @@ func (r *Resolver) Resolve(ctx context.Context, rootRef string) ([]string, error
 		if err != nil {
 			// Try pulling if configured
 			if r.puller != nil {
-				if pullErr := r.puller(ctx, currentRef); pullErr == nil {
-					// Retry resolve after pull
+				if newRef, pullErr := r.puller(ctx, currentRef); pullErr == nil {
+					// Retry resolve after pull with the new mapped local reference
+					currentRef = newRef
 					desc, err = r.store.Resolve(ctx, currentRef)
 				} else {
 					// Return original error wrapped with pull error context

--- a/pkg/resolution/resolver_test.go
+++ b/pkg/resolution/resolver_test.go
@@ -43,7 +43,7 @@ func TestResolve_PullMissing(t *testing.T) {
 
 	// Mock Puller
 	pullCalled := false
-	mockPuller := func(ctx context.Context, ref string) error {
+	mockPuller := func(ctx context.Context, ref string) (string, error) {
 		if ref == rootRef {
 			pullCalled = true
 			// Simulate pull by pushing to store
@@ -74,12 +74,15 @@ func TestResolve_PullMissing(t *testing.T) {
 			// If I can't check, I'll assume standard ORAS usage.
 			err := st.Push(ctx, manifestDesc, bytes.NewReader(manifestBytes))
 			if err != nil {
-				return err
+				return "", err
 			}
 			// Tag it
-			return st.Tag(ctx, manifestDesc, rootRef)
+			if err := st.Tag(ctx, manifestDesc, rootRef); err != nil {
+				return "", err
+			}
+			return rootRef, nil
 		}
-		return fmt.Errorf("unexpected pull for %s", ref)
+		return "", fmt.Errorf("unexpected pull for %s", ref)
 	}
 
 	// Create Resolver with Puller

--- a/pkg/source/file.go
+++ b/pkg/source/file.go
@@ -1,0 +1,44 @@
+package source
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/andrewhowdencom/skr/pkg/skill"
+	"github.com/andrewhowdencom/skr/pkg/store"
+)
+
+type FileFetcher struct{}
+
+func (f *FileFetcher) Fetch(ctx context.Context, st *store.Store, ref Reference) (Reference, error) {
+	// Validate it exists
+	info, err := os.Stat(ref.Path)
+	if err != nil {
+		return Reference{}, fmt.Errorf("invalid file path %s: %w", ref.Path, err)
+	}
+	if !info.IsDir() {
+		return Reference{}, fmt.Errorf("file source path %s must be a directory", ref.Path)
+	}
+
+	// Read SKILL.md to build annotations
+	s, err := skill.LoadUnverified(ref.Path)
+	if err != nil {
+		return Reference{}, fmt.Errorf("failed to load skill from file path %s: %w", ref.Path, err)
+	}
+
+	tag := fmt.Sprintf("%s:latest", s.Name)
+	if s.Metadata.Author != "" && s.Metadata.Version != "" {
+		tag = fmt.Sprintf("%s/%s:%s", s.Metadata.Author, s.Name, s.Metadata.Version)
+	}
+
+	// Prepare Annotations map
+	annotations := buildAnnotationsFromSkill(s)
+
+	if err := st.Build(ctx, ref.Path, tag, annotations); err != nil {
+		return Reference{}, fmt.Errorf("failed to build local file skill %s: %w", ref.Path, err)
+	}
+
+	// Returning the newly created OCI reference
+	return ParseReference("oci://" + tag), nil
+}

--- a/pkg/source/file_test.go
+++ b/pkg/source/file_test.go
@@ -1,0 +1,101 @@
+package source
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/andrewhowdencom/skr/pkg/store"
+)
+
+func TestFileFetcher_Fetch(t *testing.T) {
+	// Create a temp directory for the store
+	storeDir, err := os.MkdirTemp("", "skr-test-store-*")
+	if err != nil {
+		t.Fatalf("failed to create store temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(storeDir) }()
+
+	st, err := store.New(storeDir)
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+
+	// Create a temp directory for the dummy skill
+	skillDir, err := os.MkdirTemp("", "skr-test-skill-*")
+	if err != nil {
+		t.Fatalf("failed to create skill temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(skillDir) }()
+
+	// Write a mock SKILL.md
+	skillYaml := `---
+name: test-skill
+description: A mock skill for testing
+metadata:
+  version: 1.0.0
+  author: tester
+dependencies:
+  - "github.com/another/skill"
+commands:
+  hello:
+    description: Prints hello
+    run: "echo hello"
+---
+`
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(skillYaml), 0644); err != nil {
+		t.Fatalf("failed to write SKILL.md: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		ref     Reference
+		wantErr bool
+	}{
+		{
+			name:    "valid local directory",
+			ref:     Reference{Original: "file://" + skillDir, Schema: SchemaFile, Path: skillDir, Spec: "latest"},
+			wantErr: false,
+		},
+		{
+			name:    "invalid non-existent directory",
+			ref:     Reference{Original: "file:///does/not/exist", Schema: SchemaFile, Path: "/does/not/exist", Spec: "latest"},
+			wantErr: true,
+		},
+		{
+			name:    "invalid path (file instead of dir)",
+			ref:     Reference{Original: "file://" + filepath.Join(skillDir, "SKILL.md"), Schema: SchemaFile, Path: filepath.Join(skillDir, "SKILL.md"), Spec: "latest"},
+			wantErr: true,
+		},
+	}
+
+	ctx := context.Background()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &FileFetcher{}
+			got, err := f.Fetch(ctx, st, tt.ref)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("FileFetcher.Fetch() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr {
+				if got.Schema != SchemaOCI {
+					t.Errorf("Expected resulting reference schema to be OCI, got %s", got.Schema)
+				}
+				if got.Path != "tester/test-skill" {
+					t.Errorf("Expected resulting reference path to be tester/test-skill, got %s", got.Path)
+				}
+				if got.Spec != "1.0.0" {
+					t.Errorf("Expected resulting reference spec to be 1.0.0, got %s", got.Spec)
+				}
+
+				// Check if artifact is actually in store
+				resolveRef := got.Path + ":" + got.Spec
+				if _, resolveErr := st.Resolve(ctx, resolveRef); resolveErr != nil {
+					t.Errorf("Expected artifact %s to be resolved in store, got error: %v", resolveRef, resolveErr)
+				}
+			}
+		})
+	}
+}

--- a/pkg/source/git.go
+++ b/pkg/source/git.go
@@ -1,0 +1,72 @@
+package source
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/andrewhowdencom/skr/pkg/skill"
+	"github.com/andrewhowdencom/skr/pkg/store"
+)
+
+type GitFetcher struct{}
+
+func (f *GitFetcher) Fetch(ctx context.Context, st *store.Store, ref Reference) (Reference, error) {
+	tempDir, err := os.MkdirTemp("", "skr-git-clone-*")
+	if err != nil {
+		return Reference{}, fmt.Errorf("failed to create temp dir for git clone: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(tempDir) }()
+
+	// Construct Git URL
+	fetchURL := ref.Path
+
+	cmd := exec.CommandContext(ctx, "git", "clone", fetchURL, tempDir)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return Reference{}, fmt.Errorf("failed to clone git repository %s: %s (%w)", fetchURL, strings.TrimSpace(stderr.String()), err)
+	}
+
+	// Checkout specific ref if provided
+	if ref.Spec != "" && ref.Spec != "latest" {
+		checkoutCmd := exec.CommandContext(ctx, "git", "-C", tempDir, "checkout", ref.Spec)
+		var coStderr bytes.Buffer
+		checkoutCmd.Stderr = &coStderr
+		if err := checkoutCmd.Run(); err != nil {
+			return Reference{}, fmt.Errorf("failed to checkout ref %s: %s (%w)", ref.Spec, strings.TrimSpace(coStderr.String()), err)
+		}
+	}
+
+	// Get short SHA for tagging
+	shaCmd := exec.CommandContext(ctx, "git", "-C", tempDir, "rev-parse", "--short", "HEAD")
+	shaBytes, err := shaCmd.Output()
+	var shortSHA string
+	if err == nil && len(shaBytes) > 0 {
+		shortSHA = string(bytes.TrimSpace(shaBytes))
+	}
+
+	s, err := skill.LoadUnverified(tempDir)
+	if err != nil {
+		return Reference{}, fmt.Errorf("failed to load skill from git repository %s: %w", ref.Path, err)
+	}
+
+	tag := fmt.Sprintf("%s:latest", s.Name)
+	if s.Metadata.Author != "" && s.Metadata.Version != "" {
+		tag = fmt.Sprintf("%s/%s:%s", s.Metadata.Author, s.Name, s.Metadata.Version)
+	} else if shortSHA != "" {
+		tag = fmt.Sprintf("%s:%s", s.Name, shortSHA)
+	}
+
+	annotations := buildAnnotationsFromSkill(s)
+	annotations["org.opencontainers.image.source"] = fetchURL
+
+	if err := st.Build(ctx, tempDir, tag, annotations); err != nil {
+		return Reference{}, fmt.Errorf("failed to build local oci image from git %s: %w", ref.Path, err)
+	}
+
+	return ParseReference("oci://" + tag), nil
+}

--- a/pkg/source/git_test.go
+++ b/pkg/source/git_test.go
@@ -1,0 +1,101 @@
+package source
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/andrewhowdencom/skr/pkg/store"
+)
+
+func TestGitFetcher_Fetch(t *testing.T) {
+	// Create a temp directory for the store
+	storeDir, err := os.MkdirTemp("", "skr-test-store-*")
+	if err != nil {
+		t.Fatalf("failed to create store temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(storeDir) }()
+
+	st, err := store.New(storeDir)
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+
+	// Create a mock git repository to clone from
+	repoDir, err := os.MkdirTemp("", "skr-test-git-repo-*")
+	if err != nil {
+		t.Fatalf("failed to create repo temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(repoDir) }()
+
+	// Initialize git repo
+	if err := exec.Command("git", "init", repoDir).Run(); err != nil {
+		t.Fatalf("failed to init git: %v", err)
+	}
+	_ = exec.Command("git", "-C", repoDir, "config", "user.email", "test@example.com").Run()
+	_ = exec.Command("git", "-C", repoDir, "config", "user.name", "tester").Run()
+
+	skillYaml := `---
+name: git-test-skill
+metadata:
+  version: 2.0.0
+  author: git-tester
+---
+`
+	if err := os.WriteFile(filepath.Join(repoDir, "SKILL.md"), []byte(skillYaml), 0644); err != nil {
+		t.Fatalf("failed to write SKILL.md: %v", err)
+	}
+
+	_ = exec.Command("git", "-C", repoDir, "add", "SKILL.md").Run()
+	if err := exec.Command("git", "-C", repoDir, "commit", "-m", "init").Run(); err != nil {
+		t.Fatalf("failed to commit: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		ref     Reference
+		wantErr bool
+	}{
+		{
+			name:    "valid local git repository",
+			ref:     Reference{Original: "file://" + repoDir, Schema: SchemaGit, Path: repoDir, Spec: ""},
+			wantErr: false,
+		},
+		{
+			name:    "invalid git repository",
+			ref:     Reference{Original: "https://does-not-exist.github.com/nothing", Schema: SchemaGit, Path: "https://does-not-exist.github.com/nothing", Spec: "main"},
+			wantErr: true,
+		},
+	}
+
+	ctx := context.Background()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &GitFetcher{}
+			got, err := f.Fetch(ctx, st, tt.ref)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GitFetcher.Fetch() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr {
+				if got.Schema != SchemaOCI {
+					t.Errorf("Expected resulting reference schema to be OCI, got %s", got.Schema)
+				}
+				if got.Path != "git-tester/git-test-skill" {
+					t.Errorf("Expected resulting reference path to be git-tester/git-test-skill, got %s", got.Path)
+				}
+				if got.Spec != "2.0.0" {
+					t.Errorf("Expected resulting reference spec to be 2.0.0, got %s", got.Spec)
+				}
+
+				// Check if artifact is actually in store
+				resolveRef := got.Path + ":" + got.Spec
+				if _, resolveErr := st.Resolve(ctx, resolveRef); resolveErr != nil {
+					t.Errorf("Expected artifact %s to be resolved in store, got error: %v", resolveRef, resolveErr)
+				}
+			}
+		})
+	}
+}

--- a/pkg/source/oci.go
+++ b/pkg/source/oci.go
@@ -1,0 +1,25 @@
+package source
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/andrewhowdencom/skr/pkg/registry"
+	"github.com/andrewhowdencom/skr/pkg/store"
+)
+
+type OCIFetcher struct{}
+
+func (f *OCIFetcher) Fetch(ctx context.Context, st *store.Store, ref Reference) (Reference, error) {
+	pullRef := ref.Path
+	if ref.Spec != "" {
+		pullRef += ":" + ref.Spec
+	}
+
+	if _, err := registry.Pull(ctx, st, pullRef); err != nil {
+		return Reference{}, fmt.Errorf("failed to pull OCI reference %s: %w", pullRef, err)
+	}
+
+	// Returns the identical reference
+	return ref, nil
+}

--- a/pkg/source/reference.go
+++ b/pkg/source/reference.go
@@ -1,0 +1,78 @@
+package source
+
+import (
+	"strings"
+)
+
+const (
+	SchemaOCI  = "oci"
+	SchemaFile = "file"
+	SchemaGit  = "git"
+	SchemaHTTP = "http"
+)
+
+// Reference represents a parsed skill source reference.
+type Reference struct {
+	Original string
+	Schema   string
+	Path     string
+	Spec     string
+}
+
+// ParseReference parses a raw reference string into its Schema, Path, and Spec components.
+func ParseReference(raw string) Reference {
+	ref := Reference{Original: raw}
+	workingRaw := raw
+
+	// 1. Detect Schema
+	if strings.HasPrefix(workingRaw, "file://") {
+		ref.Schema = SchemaFile
+		workingRaw = strings.TrimPrefix(workingRaw, "file://")
+	} else if strings.HasPrefix(workingRaw, "git://") || strings.HasPrefix(workingRaw, "git@") {
+		ref.Schema = SchemaGit
+	} else if strings.HasPrefix(workingRaw, "git+https://") || strings.HasPrefix(workingRaw, "git+http://") || strings.HasPrefix(workingRaw, "git+ssh://") {
+		ref.Schema = SchemaGit
+		workingRaw = strings.TrimPrefix(workingRaw, "git+")
+	} else if strings.HasPrefix(workingRaw, "https://") || strings.HasPrefix(workingRaw, "http://") {
+		ref.Schema = SchemaHTTP
+	} else if strings.HasPrefix(workingRaw, "oci://") {
+		ref.Schema = SchemaOCI
+		workingRaw = strings.TrimPrefix(workingRaw, "oci://")
+	} else {
+		// Rule: in the absence of a schema, it's OCI.
+		ref.Schema = SchemaOCI
+	}
+
+	// 2. Extract Spec
+	switch ref.Schema {
+	case SchemaOCI:
+		// OCI uses ':' for tags
+		idx := strings.LastIndex(workingRaw, ":")
+		if idx != -1 && !strings.Contains(workingRaw[idx:], "/") {
+			ref.Path = workingRaw[:idx]
+			ref.Spec = workingRaw[idx+1:]
+		} else {
+			ref.Path = workingRaw
+			ref.Spec = "latest"
+		}
+	case SchemaGit:
+		// Git references use '#' for refspecs
+		idx := strings.LastIndex(workingRaw, "#")
+		if idx != -1 {
+			ref.Path = workingRaw[:idx]
+			ref.Spec = workingRaw[idx+1:]
+		} else {
+			ref.Path = workingRaw
+			// For git, empty implies default branch behavior
+			ref.Spec = ""
+		}
+	case SchemaFile:
+		ref.Path = workingRaw
+		ref.Spec = "latest"
+	case SchemaHTTP:
+		ref.Path = workingRaw
+		ref.Spec = "latest"
+	}
+
+	return ref
+}

--- a/pkg/source/reference_test.go
+++ b/pkg/source/reference_test.go
@@ -1,0 +1,79 @@
+package source
+
+import (
+	"testing"
+)
+
+func TestParseReference(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want Reference
+	}{
+		{
+			name: "oci with schema and tag",
+			raw:  "oci://ghcr.io/user/skill:v1.0.0",
+			want: Reference{Original: "oci://ghcr.io/user/skill:v1.0.0", Schema: SchemaOCI, Path: "ghcr.io/user/skill", Spec: "v1.0.0"},
+		},
+		{
+			name: "oci implicit without tag",
+			raw:  "ghcr.io/user/skill",
+			want: Reference{Original: "ghcr.io/user/skill", Schema: SchemaOCI, Path: "ghcr.io/user/skill", Spec: "latest"},
+		},
+		{
+			name: "oci implicit with tag",
+			raw:  "ghcr.io/user/skill:latest",
+			want: Reference{Original: "ghcr.io/user/skill:latest", Schema: SchemaOCI, Path: "ghcr.io/user/skill", Spec: "latest"},
+		},
+		{
+			name: "oci implicit with port and without tag",
+			raw:  "localhost:5000/user/skill",
+			want: Reference{Original: "localhost:5000/user/skill", Schema: SchemaOCI, Path: "localhost:5000/user/skill", Spec: "latest"},
+		},
+		{
+			name: "oci implicit with port and tag",
+			raw:  "localhost:5000/user/skill:v2",
+			want: Reference{Original: "localhost:5000/user/skill:v2", Schema: SchemaOCI, Path: "localhost:5000/user/skill", Spec: "v2"},
+		},
+		{
+			name: "file with schema",
+			raw:  "file:///path/to/skill",
+			want: Reference{Original: "file:///path/to/skill", Schema: SchemaFile, Path: "/path/to/skill", Spec: "latest"},
+		},
+		{
+			name: "git with schema and refspec",
+			raw:  "git://github.com/user/skill.git#main",
+			want: Reference{Original: "git://github.com/user/skill.git#main", Schema: SchemaGit, Path: "git://github.com/user/skill.git", Spec: "main"},
+		},
+		{
+			name: "git https with schema and refspec",
+			raw:  "git+https://github.com/user/skill.git#v1.2.3",
+			want: Reference{Original: "git+https://github.com/user/skill.git#v1.2.3", Schema: SchemaGit, Path: "https://github.com/user/skill.git", Spec: "v1.2.3"},
+		},
+		{
+			name: "git ssh without refspec",
+			raw:  "git@github.com:user/skill.git",
+			want: Reference{Original: "git@github.com:user/skill.git", Schema: SchemaGit, Path: "git@github.com:user/skill.git", Spec: ""},
+		},
+		{
+			name: "http pure defaults to http schema",
+			raw:  "https://github.com/user/skill.git",
+			want: Reference{Original: "https://github.com/user/skill.git", Schema: SchemaHTTP, Path: "https://github.com/user/skill.git", Spec: "latest"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseReference(tt.raw)
+			if got.Schema != tt.want.Schema {
+				t.Errorf("ParseReference().Schema = %v, want %v", got.Schema, tt.want.Schema)
+			}
+			if got.Path != tt.want.Path {
+				t.Errorf("ParseReference().Path = %v, want %v", got.Path, tt.want.Path)
+			}
+			if got.Spec != tt.want.Spec {
+				t.Errorf("ParseReference().Spec = %v, want %v", got.Spec, tt.want.Spec)
+			}
+		})
+	}
+}

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -1,0 +1,53 @@
+package source
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/andrewhowdencom/skr/pkg/skill"
+	"github.com/andrewhowdencom/skr/pkg/store"
+)
+
+// Fetcher defines how to fetch and prepare a skill source to be stored as an OCI artifact.
+type Fetcher interface {
+	// Fetch retrieves the skill from the reference, builds it if necessary,
+	// stores it in the local store, and returns the resulting Reference (which will map to an OCI reference).
+	Fetch(ctx context.Context, st *store.Store, ref Reference) (Reference, error)
+}
+
+// GetFetcher returns the appropriate Fetcher based on the parsed reference schema.
+func GetFetcher(ref Reference) (Fetcher, error) {
+	switch ref.Schema {
+	case SchemaFile:
+		return &FileFetcher{}, nil
+	case SchemaGit:
+		return &GitFetcher{}, nil
+	case SchemaOCI:
+		return &OCIFetcher{}, nil
+	case SchemaHTTP:
+		return nil, fmt.Errorf("HTTP(S) static hosting is not yet implemented. To install a git repository over HTTPS, use the 'git+https://' schema")
+	default:
+		return nil, fmt.Errorf("unknown schema %s", ref.Schema)
+	}
+}
+
+func buildAnnotationsFromSkill(s *skill.Skill) map[string]string {
+	annotations := make(map[string]string)
+	annotations["org.opencontainers.image.title"] = s.Name
+	if s.Description != "" {
+		annotations["org.opencontainers.image.description"] = s.Description
+		annotations["com.skr.description"] = s.Description
+	}
+	if s.Metadata.Author != "" {
+		annotations["com.skr.author"] = s.Metadata.Author
+	}
+	if s.Metadata.Version != "" {
+		annotations["com.skr.version"] = s.Metadata.Version
+	}
+	if len(s.Dependencies) > 0 {
+		if depsJSON, err := json.Marshal(s.Dependencies); err == nil {
+			annotations["com.skr.dependencies"] = string(depsJSON)
+		}
+	}
+	return annotations
+}


### PR DESCRIPTION
Design:
  Implemented the `pkg/source` module with Fetcher interfaces
  to handle schemas including Local (`file://`), Git (`git://`, `git+https://`),
  and OCI. Abstracted the installation flow to natively utilize these dynamic
  fetchers, bypassing strict OCI registry requirements.

Tradeoffs:
  Dynamic URL parsing prior to invoking dependency resolution inherently
  adds minor overhead compared to native ORAS fetching. However, it
  significantly bolsters UX by shielding the end user from CI/CD complexity
  by transparently caching foreign directories as local OCI artifacts.

Justification:
  Users explicitly desire to manage Agent Skills from remote Git repositories
  or local environments natively, as setting up automated OCI deployment
  pipelines introduces disproportionate friction for simple configurations.