### PR TITLE
Fix missing DockerProvider and RefreshToken

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -31,7 +31,6 @@ func (s *Store) Get(ctx context.Context, serverAddress string) (auth.Credential,
 	chain := &ChainProvider{
 		Providers: []CredentialProvider{
 			&DefaultYAMLProvider{},
-			&DockerProvider{},
 			&KeyringProvider{},
 			&LegacyJSONProvider{},
 		},

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -1,0 +1,70 @@
+package auth
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/adrg/xdg"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestStore_Get_PopulatesRefreshToken(t *testing.T) {
+	// Prepare a temporary XDG_CONFIG_HOME
+	tmpDir, err := os.MkdirTemp("", "xdg-config-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	oldXDG := os.Getenv("XDG_CONFIG_HOME")
+	defer os.Setenv("XDG_CONFIG_HOME", oldXDG)
+	os.Setenv("XDG_CONFIG_HOME", tmpDir)
+	xdg.Reload()
+	defer xdg.Reload()
+
+	// Write mock authentication.yaml for DefaultYAMLProvider
+	skrConfigDir := filepath.Join(tmpDir, "skr")
+	err = os.MkdirAll(skrConfigDir, 0755)
+	require.NoError(t, err)
+
+	authYAMLPath := filepath.Join(skrConfigDir, "authentication.yaml")
+	
+	// Create mock credentials that include a RefreshToken
+	mockCreds := map[string]yamlCreds{
+		"userpass.com": {
+			Username:     "testuser",
+			Password:     "testpass",
+			RefreshToken: "testrefresh1",
+		},
+		"token.com": {
+			Token:        "testtoken",
+			RefreshToken: "testrefresh2",
+		},
+	}
+	
+	yamlData, err := yaml.Marshal(mockCreds)
+	require.NoError(t, err)
+	err = os.WriteFile(authYAMLPath, yamlData, 0644)
+	require.NoError(t, err)
+
+	store := NewStore()
+	ctx := context.Background()
+
+	cred1, err := store.Get(ctx, "userpass.com")
+	require.NoError(t, err)
+
+	assert.Equal(t, "testuser", cred1.Username)
+	assert.Equal(t, "testpass", cred1.Password)
+	assert.Equal(t, "", cred1.AccessToken)
+	assert.Equal(t, "testrefresh1", cred1.RefreshToken)
+
+	cred2, err := store.Get(ctx, "token.com")
+	require.NoError(t, err)
+
+	assert.Equal(t, "", cred2.Username)
+	assert.Equal(t, "", cred2.Password)
+	assert.Equal(t, "testtoken", cred2.AccessToken)
+	assert.Equal(t, "testrefresh2", cred2.RefreshToken)
+}

--- a/pkg/auth/supplier.go
+++ b/pkg/auth/supplier.go
@@ -6,9 +6,10 @@ import (
 
 // Credential holds authentication data.
 type Credential struct {
-	Username string
-	Password string
-	Token    string
+	Username     string
+	Password     string
+	Token        string
+	RefreshToken string
 }
 
 // CredentialProvider retrieves credentials for a specific server.

--- a/pkg/auth/suppliers.go
+++ b/pkg/auth/suppliers.go
@@ -35,9 +35,10 @@ type YAMLFileProvider struct {
 }
 
 type yamlCreds struct {
-	Username string `yaml:"username,omitempty"`
-	Password string `yaml:"password,omitempty"`
-	Token    string `yaml:"token,omitempty"`
+	Username     string `yaml:"username,omitempty"`
+	Password     string `yaml:"password,omitempty"`
+	Token        string `yaml:"token,omitempty"`
+	RefreshToken string `yaml:"refresh_token,omitempty"`
 }
 
 func (s *YAMLFileProvider) Get(ctx context.Context, serverAddress string) (*Credential, error) {
@@ -56,13 +57,16 @@ func (s *YAMLFileProvider) Get(ctx context.Context, serverAddress string) (*Cred
 		return nil, fmt.Errorf("no credentials found for %s in %s", serverAddress, s.Path)
 	}
 
-	// Prefer Token if available, else User/Pass
-	if creds.Token != "" {
-		return &Credential{Token: creds.Token}, nil
+	// Return all fields, allowing ORAS to handle mutual exclusion if necessary
+	cred := &Credential{
+		Username:     creds.Username,
+		Password:     creds.Password,
+		Token:        creds.Token,
+		RefreshToken: creds.RefreshToken,
 	}
 
-	if creds.Username != "" && creds.Password != "" {
-		return &Credential{Username: creds.Username, Password: creds.Password}, nil
+	if cred.Token != "" || cred.RefreshToken != "" || (cred.Username != "" && cred.Password != "") {
+		return cred, nil
 	}
 
 	return nil, fmt.Errorf("incomplete credentials for %s", serverAddress)

--- a/pkg/auth/suppliers_test.go
+++ b/pkg/auth/suppliers_test.go
@@ -18,6 +18,7 @@ ghcr.io:
   password: "testpassword"
 docker.io:
   token: "testtoken"
+  refresh_token: "testrefresh"
 `
 	tmpdb, err := os.CreateTemp("", "auth-*.yaml")
 	require.NoError(t, err)
@@ -56,6 +57,7 @@ docker.io:
 		require.NotNil(t, cred)
 
 		assert.Equal(t, "testtoken", cred.Token)
+		assert.Equal(t, "testrefresh", cred.RefreshToken)
 
 		// Verify Authenticator creation
 		auth := AuthenticatorFromCredential(cred)


### PR DESCRIPTION
Justification:
  The previous auth refactor added references to DockerProvider and
  RefreshToken that weren't implemented, leading to build errors.
  Removed the unimplemented provider and correctly updated to populate
  RefreshToken cleanly from YAML files.